### PR TITLE
should not be able to play a point card on first trick

### DIFF
--- a/js/Ai.js
+++ b/js/Ai.js
@@ -30,11 +30,13 @@ function(Player,  $){
     Ai.prototype.transferTo = function(other){
         var selected = this.selected;
         Player.prototype.transferTo.call(this, other);
-        this.brain.watch({
-            type: "in",
-            player: other,
-            cards: selected
-        });
+        if(selected){
+            this.brain.watch({
+                type: "in",
+                player: other,
+                cards: selected
+            });
+        }
     };
 
     Ai.prototype.watch = function(info){

--- a/js/Player.js
+++ b/js/Player.js
@@ -89,8 +89,10 @@ function(Row ,  Waste,   domBinding){
     Player.prototype.transferTo = function(other){
         var cards = this.selected;
         this.selected = null;
-        this.out(cards);
-        other.takeIn(cards);
+        if(cards){
+            this.out(cards);
+            other.takeIn(cards);
+        }
     };
 
     return Player;

--- a/js/game.js
+++ b/js/game.js
@@ -66,9 +66,9 @@ function(ui,   Human,   Ai,   board,   config,   $,        rules,   RandomBrain,
         });
     };
 
-    var adds = [1, 3, 2];
+    var adds = [1, 3, 2, 0];
     var getPlayerForTransfer = function(id){
-        return (id + adds[rounds % 3]) % 4;
+        return (id + adds[(rounds - 1) % 4]) % 4;
     };
 
     return {
@@ -151,7 +151,11 @@ function(ui,   Human,   Ai,   board,   config,   $,        rules,   RandomBrain,
                 'start': function(){
                     rounds++;
                     $.when.apply($, players.map(function(p){
-                        return p.prepareTransfer(rounds % 3);
+                        var dir = (rounds - 1) % 4;
+                        if(dir < 3){
+                            return p.prepareTransfer(dir);
+                        }
+                        return $.Deferred().resolve();
                     })).done(this.next.bind(this));
                 },
                 'passing': function(){

--- a/js/rules.js
+++ b/js/rules.js
@@ -28,7 +28,17 @@ define(function(){
                     return c.suit === firstSuit;
                 });
                 if(vcards.length === 0){
-                    return vcards.concat(cards);
+                    if(cards.length === 13){
+                        vcards = cards.filter(function(c){
+                            return c.suit !== 1 && !(c.suit === 0 && c.num === 11);
+                        });
+                        if(vcards.length === 0){
+                            vcards = cards;
+                        }
+                        return vcards;
+                    }else{
+                        return vcards.concat(cards);
+                    }
                 }else{
                     return vcards;
                 }


### PR DESCRIPTION
This should address the open issue about the rule that point cards (hearts and Queen of spades) are not allowed to be played on the first trick (with an edge-case exception that the player only has point cards).