### PR TITLE
should not be able to play a point card on first trick

### DIFF
--- a/js/rules.js
+++ b/js/rules.js
@@ -28,7 +28,17 @@ define(function(){
                     return c.suit === firstSuit;
                 });
                 if(vcards.length === 0){
-                    return vcards.concat(cards);
+                    if(cards.length === 13){
+                        vcards = cards.filter(function(c){
+                            return c.suit !== 1 && !(c.suit === 0 && c.num === 11);
+                        });
+                        if(vcards.length === 0){
+                            vcards = cards;
+                        }
+                        return vcards;
+                    }else{
+                        return vcards.concat(cards);
+                    }
                 }else{
                     return vcards;
                 }


### PR DESCRIPTION
This should address the open issue about the rule that point cards (hearts and Queen of spades) are not allowed to be played on the first trick (with an edge-case exception that the player only has point cards).