### PR TITLE
fix: front and back variables local declaration missing

### DIFF
--- a/js/domBinding.js
+++ b/js/domBinding.js
@@ -143,7 +143,7 @@ define(function(){
             numText.className = 'num';
             numText.innerHTML = numtext;
 
-            front = document.createElement('div');
+            var front = document.createElement('div');
             front.className = 'front';
             front.appendChild(numText);
             display.classList.add(suits[suit]);
@@ -154,7 +154,7 @@ define(function(){
 
             display.appendChild(front);
 
-            back = document.createElement('div');
+            var back = document.createElement('div');
             back.className = 'back';
 
             display.appendChild(back);


### PR DESCRIPTION
front and back variables declaration are missing locally. So, those are being added to global stack unnecessarily.

Fixed the case.